### PR TITLE
Fix `OPQ#stop/1`, stop the agent

### DIFF
--- a/lib/opq.ex
+++ b/lib/opq.ex
@@ -26,6 +26,7 @@ defmodule OPQ do
   def stop(feeder) do
     Process.flag(:trap_exit, true)
     GenStage.call(feeder, :stop, Opt.timeout(feeder))
+    Opt.stop(feeder)
   end
 
   def pause(feeder),  do: GenStage.call(feeder, :pause, Opt.timeout(feeder))

--- a/lib/opq/options_handler.ex
+++ b/lib/opq/options_handler.ex
@@ -9,6 +9,8 @@ defmodule OPQ.OptionsHandler do
 
   def timeout(feeder), do: load_opts(feeder)[:timeout]
 
+  def stop(feeder), do: Agent.stop(name(feeder))
+
   defp load_opts(feeder), do: Agent.get(name(feeder), & &1)
   defp name(feeder),      do: :"opq-#{Kernel.inspect(feeder)}"
 end

--- a/test/lib/opq_test.exs
+++ b/test/lib/opq_test.exs
@@ -151,6 +151,9 @@ defmodule OPQTest do
     OPQ.stop(opq)
 
     assert catch_exit(OPQ.enqueue(opq, :b))
+
+    agent = :"opq-#{Kernel.inspect(opq)}"
+    assert catch_exit(Agent.get(agent, & &1))
   end
 
   test "pause & resume" do


### PR DESCRIPTION
I don't know it is by design or something, so I just send this.