### PR TITLE
Use cast instead of call to enqueue

### DIFF
--- a/lib/opq.ex
+++ b/lib/opq.ex
@@ -13,7 +13,7 @@ defmodule OPQ do
   end
 
   def enqueue(feeder, event) do
-    GenStage.call(feeder, {:enqueue, event}, Opt.timeout(feeder))
+    GenStage.cast(feeder, {:enqueue, event})
   end
 
   def enqueue(feeder, mod, fun, args)
@@ -25,12 +25,12 @@ defmodule OPQ do
 
   def stop(feeder) do
     Process.flag(:trap_exit, true)
-    GenStage.call(feeder, :stop, Opt.timeout(feeder))
+    GenStage.cast(feeder, :stop)
     Opt.stop(feeder)
   end
 
-  def pause(feeder),  do: GenStage.call(feeder, :pause, Opt.timeout(feeder))
-  def resume(feeder), do: GenStage.call(feeder, :resume, Opt.timeout(feeder))
+  def pause(feeder),  do: GenStage.cast(feeder, :pause)
+  def resume(feeder), do: GenStage.cast(feeder, :resume)
   def info(feeder),   do: GenStage.call(feeder, :info, Opt.timeout(feeder))
 
   defp start_links(opts) do

--- a/test/lib/opq_test.exs
+++ b/test/lib/opq_test.exs
@@ -127,22 +127,6 @@ defmodule OPQTest do
     end
   end
 
-  test "timeout" do
-    {:ok, opq} = OPQ.init(workers: 1, interval: 10, timeout: 5)
-
-    OPQ.enqueue(opq, :a)
-
-    timeout = try do
-      OPQ.enqueue(opq, :b)
-    catch
-      :exit, _ -> true
-    else
-      _ -> false
-    end
-
-    assert timeout
-  end
-
   test "stop" do
     {:ok, opq} = OPQ.init(workers: 1)
 
@@ -150,7 +134,7 @@ defmodule OPQTest do
 
     OPQ.stop(opq)
 
-    assert catch_exit(OPQ.enqueue(opq, :b))
+    refute Process.alive?(opq)
 
     agent = :"opq-#{Kernel.inspect(opq)}"
 


### PR DESCRIPTION
When there's an increased amount of workers enqueing work on the feeder, using a `GenServer.call` is not realistic, even with a really high timeout,  and a response is not strictly required. This PR changes `call` to `cast` for `stop`, `resume`, `pause` and `enqueue`.