### PR TITLE
Fix source_url in mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule OPQ.Mixfile do
   use Mix.Project
 
-  @source_url "https://github.com/fredwu/crawler"
+  @source_url "https://github.com/fredwu/opq"
   @version "4.0.0"
 
   def project do


### PR DESCRIPTION
Small fix; I clicked the Github link on hex.pm and went to the wrong project. 